### PR TITLE
fix: prefer the later version of firefox's db

### DIFF
--- a/src/install-authority.ts
+++ b/src/install-authority.ts
@@ -106,10 +106,10 @@ async function addCertificateToNSSCertDB (commonName: string, rootCertPath: stri
   }
 
   glob.sync(nssDirGlob).forEach(potentialNSSDBDir => {
-    if (existsSync(path.join(potentialNSSDBDir, 'cert8.db')))
-      execSync(`${certutilPath} -A -d "${potentialNSSDBDir}" -t 'C,,' -i ${rootCertPath} -n ${commonName}`);
-    else if (existsSync(path.join(potentialNSSDBDir, 'cert9.db')))
+    if (existsSync(path.join(potentialNSSDBDir, 'cert9.db')))
       execSync(`${certutilPath} -A -d "sql:${potentialNSSDBDir}" -t 'C,,' -i ${rootCertPath} -n ${commonName}`);
+    else if (existsSync(path.join(potentialNSSDBDir, 'cert8.db')))
+      execSync(`${certutilPath} -A -d "${potentialNSSDBDir}" -t 'C,,' -i ${rootCertPath} -n ${commonName}`);
   });
 }
 


### PR DESCRIPTION
In the current scenario if you did update your FF then the old db is used because it still exists (FF doesn't clean it up).

This fixes that by instead preferring the new db if it exists.