### PR TITLE
Limit CA and Cert lifetime to 825 days

### DIFF
--- a/src/openssl.ts
+++ b/src/openssl.ts
@@ -139,7 +139,7 @@ export function generateKey (): string {
 export function generateRootCertificate (commonName: string, opensslConfPath: string) {
   const rootCertPath = tmpFile(`${commonName}.crt`);
   const rootKeyPath = generateKey();
-  openssl(`req -config ${opensslConfPath} -key ${rootKeyPath} -out ${rootCertPath} -new -subj "/CN=${commonName}" -x509 -days 7000 -extensions v3_ca`);
+  openssl(`req -config ${opensslConfPath} -key ${rootKeyPath} -out ${rootCertPath} -new -subj "/CN=${commonName}" -x509 -days 825 -extensions v3_ca`);
   return { rootKeyPath, rootCertPath };
 }
 
@@ -154,7 +154,7 @@ export function generateSignedCertificate (commonName: string, opensslConfPath: 
   const caCertsDir = path.join(os.tmpdir(), Math.round(Math.random() * 36 ** 10).toString(36));
   mkdirp.sync(caCertsDir);
 
-  openssl(`ca -config ${opensslConfPath} -in ${csrFile} -out ${certPath} -outdir ${caCertsDir} -keyfile ${rootKeyPath} -cert ${caPath} -notext -md sha256 -days 7000 -batch -extensions server_cert`)
+  openssl(`ca -config ${opensslConfPath} -in ${csrFile} -out ${certPath} -outdir ${caCertsDir} -keyfile ${rootKeyPath} -cert ${caPath} -notext -md sha256 -days 825 -batch -extensions server_cert`)
 
   rimraf.sync(caCertsDir);
 


### PR DESCRIPTION
Resolves ERR_CERT_REVOKED errors in Chrome on macOS 10.15 Catalina.

As decided by the CA/B Forum [1], newly created TLS certificates shall
have a maximum lifetime of 825 days (~27 months).

Apple implemented this in their latest software as a requirement for all
certificates issued after July 1, 2019 [2], presumably causing the
ERR_CERT_REVOKED error in Chrome [3].

Since this fork of devcert follows the idea of forgetting all private
keys after issuing the required certificate(s), there's no point in
giving the CA a longer lifetime than the certificate.

[1] https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/
[2] https://support.apple.com/en-us/HT210176
[3] https://support.google.com/chrome/thread/14551925?hl=en

Resolves #4