### PR TITLE
Update dependencies, apply fixes from "upstream"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/index.js').default;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/guybedford/devcert.git"
   },
   "engines": {
-    "node": "^20.11.0 || >=22.0.0"
+    "node": "^14.13.1 || >=16.0.0"
   },
   "author": "Dave Wasmer",
   "license": "MIT",
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "command-exists": "^1.2.9",
-    "get-port": "^7.1.0",
-    "glob": "^11.0.0",
-    "rimraf": "^6.0.1"
+    "get-port": "^6.1.2",
+    "glob": "^10.4.5",
+    "rimraf": "^5.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "devcert-sanscache",
   "version": "0.4.8",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
-  "main": "index.js",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    }
+  },
   "scripts": {
     "prepublish": "tsc"
   },
@@ -10,17 +19,19 @@
     "type": "git",
     "url": "git+https://github.com/guybedford/devcert.git"
   },
+  "engines": {
+    "node": "^20.11.0 || >=22.0.0"
+  },
   "author": "Dave Wasmer",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^8.0.50",
-    "typescript": "^2.6.1"
+    "@types/node": "20.11.0",
+    "typescript": "^5.5.4"
   },
   "dependencies": {
-    "command-exists": "^1.2.2",
-    "get-port": "^3.0.0",
-    "glob": "^7.1.1",
-    "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.2"
+    "command-exists": "^1.2.9",
+    "get-port": "^7.1.0",
+    "glob": "^11.0.0",
+    "rimraf": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devcert-sanscache",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import commandExists = require('command-exists');
-import installAuthority from './install-authority';
-import { generateOpensslConf, generateRootCertificate, generateSignedCertificate, tmpClear } from './openssl';
-import fs = require('fs');
+import commandExists from 'command-exists';
+import installAuthority from './install-authority.js';
+import { generateOpensslConf, generateRootCertificate, generateSignedCertificate, tmpClear } from './openssl.js';
+import fs from 'node:fs';
 
 export default async function generateDevCert (commonName: string) {
   if (!commandExists.sync('openssl'))

--- a/src/install-authority.ts
+++ b/src/install-authority.ts
@@ -137,10 +137,12 @@ function lookupOrInstallCertutil (): string | void {
   if (process.platform === 'darwin') {
     if (commandExists.sync('brew')) {
       let certutilPath: string;
+      if (!isNSSInstalled()) {
+        execSync('brew install nss');
+      }
       try {
         certutilPath = path.join(execSync('brew --prefix nss').toString().trim(), 'bin', 'certutil');
       } catch (e) {
-        execSync('brew install nss');
         certutilPath = path.join(execSync('brew --prefix nss').toString().trim(), 'bin', 'certutil');
       }
       return certutilPath;
@@ -150,5 +152,13 @@ function lookupOrInstallCertutil (): string | void {
     if (!commandExists.sync('certutil'))
       execSync('sudo apt install libnss3-tools');
     return execSync('which certutil').toString().trim();
+  }
+}
+
+function isNSSInstalled(): boolean {
+  try {
+    return execSync('brew list -1').toString().includes('\nnss\n');
+  } catch (e) {
+    return false;
   }
 }

--- a/src/install-authority.ts
+++ b/src/install-authority.ts
@@ -1,13 +1,13 @@
 import { readFileSync, existsSync } from 'fs';
 import { exec, execSync } from 'child_process';
-import http = require('http');
-import path = require('path');
-import getPort = require('get-port');
-import commandExists = require('command-exists');
-import glob = require('glob');
+import http from 'node:http';
+import path from 'node:path';
+import getPort from 'get-port';
+import commandExists from 'command-exists';
+import {glob} from 'glob';
 
 export function waitForUser () {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     function waitHandler () {
       resolve();
       process.stdin.removeListener('data', waitHandler);

--- a/src/install-authority.ts
+++ b/src/install-authority.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync } from 'fs';
-import { exec, execSync } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 import http from 'node:http';
 import path from 'node:path';
 import getPort from 'get-port';
@@ -38,7 +38,7 @@ export default function installCertificateAuthority (commonName: string, rootCer
 // `nss` Homebrew package, otherwise we go manual with user-facing prompts.
 async function addToMacTrustStores (commonName: string, rootCertPath: string): Promise<void> {
   // Chrome, Safari, system utils
-  execSync(`sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain -p ssl -p basic "${rootCertPath}"`);
+  execFileSync('sudo', ['security', 'add-trusted-cert', '-d', '-r', 'trustRoot', '-k', '/Library/Keychains/System.keychain', '-p', 'ssl', '-p', 'basic', rootCertPath]);
   // Firefox
   try {
     // Try to use certutil to install the cert automatically
@@ -57,9 +57,9 @@ async function addToMacTrustStores (commonName: string, rootCertPath: string): P
 // opening certs, if we can't use certutil, we're out of luck.
 async function addToLinuxTrustStores (commonName: string, rootCertPath: string): Promise<void> {
   // system utils
-  execSync(`sudo cp ${rootCertPath} /etc/ssl/certs/${commonName}.pem}`);
-  execSync(`sudo cp ${rootCertPath} /usr/local/share/ca-certificates/${commonName}.crt`);
-  execSync(`sudo update-ca-certificates`);
+  execFileSync('sudo', ['cp', rootCertPath, `/etc/ssl/certs/${commonName}.pem}`]);
+  execFileSync('sudo', ['cp', rootCertPath, `/usr/local/share/ca-certificates/${commonName}.crt`]);
+  execFileSync('sudo', ['update-ca-certificates']);
   // Firefox
   try {
     // Try to use certutil to install the cert automatically
@@ -81,7 +81,7 @@ async function addToLinuxTrustStores (commonName: string, rootCertPath: string):
 async function addToWindowsTrustStores (rootCertPath: string): Promise<void> {
   // IE, Chrome, system utils
   try {
-    execSync(`certutil -addstore -user root ${rootCertPath}`);
+    execFileSync('certutil', ['-addstore', '-user', 'root', rootCertPath]);
   }
   catch (e) {}
   // Firefox (don't even try NSS certutil, no easy install for Windows)
@@ -98,7 +98,7 @@ async function addCertificateToNSSCertDB (commonName: string, rootCertPath: stri
   // Firefox appears to load the NSS database in-memory on startup, and overwrite on exit. So we
   // have to ask the user to quite Firefox first so our changes don't get overwritten.
   if (checkForOpenFirefox) {
-    let runningProcesses = execSync('ps aux');
+    let runningProcesses = execFileSync('ps', ['aux']);
     if (runningProcesses.indexOf('firefox') > -1) {
       console.log('Please close Firefox\nPress <Enter> when ready');
       await waitForUser();
@@ -107,9 +107,9 @@ async function addCertificateToNSSCertDB (commonName: string, rootCertPath: stri
 
   glob.sync(nssDirGlob).forEach(potentialNSSDBDir => {
     if (existsSync(path.join(potentialNSSDBDir, 'cert8.db')))
-      execSync(`${certutilPath} -A -d "${potentialNSSDBDir}" -t 'C,,' -i ${rootCertPath} -n ${commonName}`);
+      execFileSync(certutilPath, ['-A', '-d', potentialNSSDBDir, '-t', `C,,`, '-i', rootCertPath, '-n', commonName]);
     else if (existsSync(path.join(potentialNSSDBDir, 'cert9.db')))
-      execSync(`${certutilPath} -A -d "sql:${potentialNSSDBDir}" -t 'C,,' -i ${rootCertPath} -n ${commonName}`);
+      execFileSync(certutilPath, ['-A', '-d', `sql:${potentialNSSDBDir}`, '-t', `C,,`, '-i', rootCertPath, '-n', commonName]);
   });
 }
 
@@ -127,7 +127,7 @@ async function openCertificateInFirefox(rootCertPath: string, firefoxPath: strin
   }).listen(port);
   console.log(`If using Firefox, a Firefox window will be opened for authorization.\nTick the "Trust this CA to identify websites" option and then confirm.\nPress <Enter> to continue.`);
   await waitForUser();
-  exec(`${firefoxPath} http://localhost:${port}`);
+  execFile(firefoxPath, [`http://localhost:${port}`]);
   console.log(`Press <Enter> once confirmed (or to skip)`);
   await waitForUser();
 }
@@ -138,26 +138,26 @@ function lookupOrInstallCertutil (): string | void {
     if (commandExists.sync('brew')) {
       let certutilPath: string;
       if (!isNSSInstalled()) {
-        execSync('brew install nss');
+        execFileSync('brew', ['install', 'nss']);
       }
       try {
-        certutilPath = path.join(execSync('brew --prefix nss').toString().trim(), 'bin', 'certutil');
+        certutilPath = path.join(execFileSync('brew', ['--prefix', 'nss']).toString().trim(), 'bin', 'certutil');
       } catch (e) {
-        certutilPath = path.join(execSync('brew --prefix nss').toString().trim(), 'bin', 'certutil');
+        certutilPath = path.join(execFileSync('brew', ['--prefix', 'nss']).toString().trim(), 'bin', 'certutil');
       }
       return certutilPath;
     }
   }
   else if (process.platform === 'linux') {
     if (!commandExists.sync('certutil'))
-      execSync('sudo apt install libnss3-tools');
-    return execSync('which certutil').toString().trim();
+      execFileSync('sudo', ['apt', 'install', 'libnss3-tools']);
+    return execFileSync('which', ['certutil']).toString().trim();
   }
 }
 
 function isNSSInstalled(): boolean {
   try {
-    return execSync('brew list -1').toString().includes('\nnss\n');
+    return execFileSync('brew', ['list', '-1']).toString().includes('\nnss\n');
   } catch (e) {
     return false;
   }

--- a/src/openssl.ts
+++ b/src/openssl.ts
@@ -1,9 +1,8 @@
-import childProcess = require('child_process');
-import path = require('path');
-import os = require('os');
-import rimraf = require('rimraf');
-import fs = require('fs');
-import mkdirp = require('mkdirp');
+import childProcess from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+import {rimraf} from 'rimraf';
+import fs from 'node:fs';
 
 // simple temp file pathing, requires manual removal
 let tmpPrefix, tmpFiles;
@@ -152,7 +151,8 @@ export function generateSignedCertificate (commonName: string, opensslConfPath: 
   
   // needed but not used (see https://www.mail-archive.com/openssl-users@openssl.org/msg81098.html)
   const caCertsDir = path.join(os.tmpdir(), Math.round(Math.random() * 36 ** 10).toString(36));
-  mkdirp.sync(caCertsDir);
+  
+  fs.mkdirSync(caCertsDir, {recursive: true});
 
   openssl(`ca -config ${opensslConfPath} -in ${csrFile} -out ${certPath} -outdir ${caCertsDir} -keyfile ${rootKeyPath} -cert ${caPath} -notext -md sha256 -days 825 -batch -extensions server_cert`)
 

--- a/src/openssl.ts
+++ b/src/openssl.ts
@@ -32,10 +32,10 @@ export function tmpClear () {
 }
 
 let rndFile;
-function openssl (cmd: string) {
+function openssl (args: string[]) {
   if (!rndFile)
     rndFile = tmpFile('rnd');
-  childProcess.execSync(`openssl ${ cmd }`, {
+  childProcess.execFileSync('openssl', args, {
     stdio: 'ignore',
     env: Object.assign({
       RANDFILE: rndFile
@@ -130,7 +130,7 @@ export function generateOpensslConf (commonName: string) {
 
 export function generateKey (): string {
   const keyFile = tmpFile('key');
-  openssl(`genrsa -out ${keyFile} 2048`);
+  openssl(['genrsa', '-out', keyFile, '2048']);
   fs.chmodSync(keyFile, 400);
   return keyFile;
 }
@@ -138,7 +138,7 @@ export function generateKey (): string {
 export function generateRootCertificate (commonName: string, opensslConfPath: string) {
   const rootCertPath = tmpFile(`${commonName}.crt`);
   const rootKeyPath = generateKey();
-  openssl(`req -config ${opensslConfPath} -key ${rootKeyPath} -out ${rootCertPath} -new -subj "/CN=${commonName}" -x509 -days 825 -extensions v3_ca`);
+  openssl(['req', '-config', opensslConfPath, '-key', rootKeyPath, '-out', rootCertPath, '-new', '-subj', `/CN=${commonName}`, '-x509', '-days', '825', '-extensions', 'v3_ca']);
   return { rootKeyPath, rootCertPath };
 }
 
@@ -146,7 +146,7 @@ export function generateSignedCertificate (commonName: string, opensslConfPath: 
   const keyPath = generateKey();
   process.env.SAN = commonName;
   const csrFile = tmpFile(`${commonName}.csr`);
-  openssl(`req -config ${ opensslConfPath } -subj "/CN=${commonName}" -key ${keyPath} -out ${csrFile} -new`);
+  openssl(['req', '-config', opensslConfPath, '-subj', `/CN=${commonName}`, '-key', keyPath, '-out', csrFile, '-new']);
   const certPath = tmpFile(`${commonName}.crt`);
   
   // needed but not used (see https://www.mail-archive.com/openssl-users@openssl.org/msg81098.html)
@@ -154,7 +154,7 @@ export function generateSignedCertificate (commonName: string, opensslConfPath: 
   
   fs.mkdirSync(caCertsDir, {recursive: true});
 
-  openssl(`ca -config ${opensslConfPath} -in ${csrFile} -out ${certPath} -outdir ${caCertsDir} -keyfile ${rootKeyPath} -cert ${caPath} -notext -md sha256 -days 825 -batch -extensions server_cert`)
+  openssl(['ca', '-config', opensslConfPath, '-in', csrFile, '-out', certPath, '-outdir', caCertsDir, '-keyfile', rootKeyPath, '-cert', caPath, '-notext', '-md', 'sha256', '-days', '825', '-batch', '-extensions', 'server_cert'])
 
   rimraf.sync(caCertsDir);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "typeRoots": ["node_modules/@types"],
-    "module": "commonjs",
+    "module": "node16",
     "target": "esnext",
     "noImplicitAny": false,
     "sourceMap": true,


### PR DESCRIPTION
This PR was mainly targeted at updating npm dependencies in order to resolve deprecation warnings produced by "npm install" right now:

```sh
❯ npm i
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
```

One of the dependencies switched to ESM, so I had to do the same for this package in order to use imports. Hope that is fine with you. This is a breaking change for consumers that are still using CommonJS.

While checking the origin project "[davewasmer/devcert](https://github.com/davewasmer/devcert)" I noticed two changes that I found reasonable to apply to this fork, see below.

I also included the 0.4.8 commit in this PR since it is missing on master but the tag is there.

I only tested these changes on macOS. Thank you for taking your time to look into this!

### First Commit

**[refactor: Update dependencies and switch to ESM](https://github.com/guybedford/devcert/commit/e5478722f9a98f297df9336e9ed5c2a30a49db62)** 

* Update all npm dependencies to resolve install warnings regarding
  deprecated modules.
* Add an 'engines' declaration to package.json since the current
  version of 'glob' requires Node 20 or 22
* Change the package to ESM since dependency 'get-port' is ESM and can't
  be require'd anymore: https://github.com/sindresorhus/get-port/releases/tag/v6.0.0

### Second Commit

**[fix(darwin): Properly detect whether nss has been installed when using brew](https://github.com/guybedford/devcert/commit/decea005e1b689cac914de847670e14bababe167)**

Basically applying https://github.com/davewasmer/devcert/commit/a1815d75d2654e59ec2b57b59ded5a232f9ac950 and following changes made in davewasmer/devcert

I ran into this while testing on my machine.

### Third Commit

**[fix: Switch from execSync to execFileSync to reduce risk of remote code execution](https://github.com/guybedford/devcert/commit/16ec6e809b1b8d0a2bc0295ca1bf3756fffed028)**

Adapted from https://github.com/davewasmer/devcert/commit/e0e8ae31c7a5f2371f091f27ced65ed43e7752c2


